### PR TITLE
Updated chromedriver version from 2.24 to 2.32

### DIFF
--- a/bin/install_chromedriver
+++ b/bin/install_chromedriver
@@ -2,9 +2,9 @@
 
 source "$(dirname "$0")/setup.sh"
 
-CHROMEDRIVER_LINUX_32_URL='http://chromedriver.storage.googleapis.com/2.24/chromedriver_linux32.zip'
-CHROMEDRIVER_LINUX_64_URL='http://chromedriver.storage.googleapis.com/2.24/chromedriver_linux64.zip'
-CHROMEDRIVER_MAC_URL='http://chromedriver.storage.googleapis.com/2.24/chromedriver_mac64.zip'
+CHROMEDRIVER_LINUX_32_URL='http://chromedriver.storage.googleapis.com/2.32/chromedriver_linux32.zip'
+CHROMEDRIVER_LINUX_64_URL='http://chromedriver.storage.googleapis.com/2.32/chromedriver_linux64.zip'
+CHROMEDRIVER_MAC_URL='http://chromedriver.storage.googleapis.com/2.32/chromedriver_mac64.zip'
 
 if [[ "${SV_S_BINARIES}" == 'Linux64'  ]]; then
    CHROMEDRIVER_URL=$CHROMEDRIVER_LINUX_64_URL
@@ -32,4 +32,3 @@ fi
 
 unzip chromedriver*.zip
 rm chromedriver*.zip
-


### PR DESCRIPTION
This PR is to update the chromedriver version which will fix issues on macs whereby tests are failing on interacting with elements outside the viewport. This affects [tripapp](https://github.com/holidayextras/tripapplite)

To test this locally there are a few steps required.

1. Once you have cloned the repository ensure you are on the same version of node as in tripapp (currently `8.5.0`) - `nvm use 8.5.0`
1. Run `npm link` from the `sv-selenium` repo
1. Navigate to the tripapp repository then run `npm link sv-selenium`. You may or may not have to `rm -rf node_modules/sv-selenium` beforehand.
1. Remove the `tmp` files setup from `sv-selenium`, `rm -rf /tmp/sv-selenium`
1. Pick a failing selenium test `selenium/pageTests/v2.holidayextras.co.uk/mobileLoungeBookingSummary.js` this one should fail locally
1. Now it should pass 🎉 